### PR TITLE
Name cannot be None when retrieving the details of a package

### DIFF
--- a/fedoratagger/frontend/app.py
+++ b/fedoratagger/frontend/app.py
@@ -152,6 +152,7 @@ def details(name):
 
     Return a list of details for a package.
     """
+    name = name or flask.request.args.get('name', None)
 
     items = [
         item_template.format(


### PR DESCRIPTION
Start work for https://github.com/fedora-infra/fedora-tagger/issues/76 unfortunately, I could not have tagger run locally, so I'm not quite sure I found all the problems, but this is a start.
