### PR TITLE
Gracefully degrade if the fedora-packages app is unavailable.

### DIFF
--- a/fedoratagger/lib/model.py
+++ b/fedoratagger/lib/model.py
@@ -124,7 +124,7 @@ class Package(DeclarativeBase):
         if not getattr(self, '_meta', None):
             try:
                 self._meta = pkgwat.api.get(self.name)
-            except KeyError:
+            except Exception:
                 self._meta = {}
 
         return self._meta


### PR DESCRIPTION
This avoids a circular dependency between the apps.

tagger needs packages to run.

packages needs tagger to bootstrap itself.
