### PR TITLE
filter

### DIFF
--- a/fedoratagger/lib/update.py
+++ b/fedoratagger/lib/update.py
@@ -117,7 +117,8 @@ def update_summaries(N=100):
         log.warn("No access to yum.  Aborting.")
         return
 
-    query = ft.SESSION.query(m.Package).filter_by(summary=u'')
+    query = ft.SESSION.query(m.Package).filter(
+                                  m.Package.summary.in_([u'', u'(no summary)']))
     log.info("There are %i such packages... hold on." % query.count())
 
     # We limit this to only getting the first N summaries, since querying yum


### PR DESCRIPTION
filter change packages to load summary with ('no summary').
when re-running the script does not bring the package they have ('no summary')
