### PR TITLE
Open package details in a new tab

### DIFF
--- a/fedoratagger/frontend/widgets/templates/card.mak
+++ b/fedoratagger/frontend/widgets/templates/card.mak
@@ -8,7 +8,12 @@
             <div class="icon"><img src="${w.package.icon}"/></div>
           % endif
           <div>
-            <h2><a href="https://apps.fedoraproject.org/packages/${w.package.name}">${w.package.name}</a></h2>
+            <h2>
+	      <a href="https://apps.fedoraproject.org/packages/${w.package.name}"
+	        target="_blank">
+	        ${w.package.name}
+	      </a>
+            </h2>
           </div>
           <div class="summary">
            % if w.package.summary:


### PR DESCRIPTION
This patch facilitates user to open package details in a new tab
instead of opening it in the same tab so that he/she can vote or add
tags to the package while looking at its details.

The patch fixes issue #177.
