### PR TITLE
Floor the rating for fedmsg messages.

### DIFF
--- a/fedoratagger/lib/model.py
+++ b/fedoratagger/lib/model.py
@@ -190,7 +190,7 @@ class Package(DeclarativeBase):
             'name': self.name,
             'summary': self.summary,
             'tags': tags,
-            'rating': float(rating),
+            'rating': int(rating),
             'usage': self.usage,
             'icon': self.icon,
         }


### PR DESCRIPTION
This, like in fedora-infra/fedmsg#201, is just to reduce erroneous
fedmsg validation failures.   Without this, the rating gets encoded on
one machines as 0.9111111111112 on one machine and as 0.91111111111 on
another.  Those are not the same strings, and so the signature
computation produces different signatures -- recipients think that the
message is "invalid".
